### PR TITLE
tweak build to demo bundling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ Compile / npmDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.cascaval" %%% "three-typings" % "0.1.7-SNAPSHOT",
+  "org.cascaval" %%% "scala-threejs-facades" % "0.131.1-SNAPSHOT",
   ("org.scala-js" %%% "scalajs-dom" % "1.2.0").cross(CrossVersion.for3Use2_13)
 )
+
+webpackBundlingMode := BundlingMode.LibraryOnly()

--- a/src/main/scala/examples/TestMain.scala
+++ b/src/main/scala/examples/TestMain.scala
@@ -29,7 +29,7 @@ object TestMain:
     scene.add(cube)
 
     val text = Text()
-    text.text = "Hello World"
+    text.text = "Hello Bundling!"
     text.fontSize = 0.2
     text.position.x = 5
     text.position.z = -2

--- a/web/index.html
+++ b/web/index.html
@@ -12,8 +12,19 @@
 </head>
 
 <body>
+  <!-- 
+    using the LibraryOnly bundling mode from ScalaJS Bundler, described here:
+      https://github.com/scalacenter/scalajs-bundler/blob/master/manual/src/ornate/reference.md#library-only-bundling-mode-library-only.
+    this relies on `webpackBundlingMode := BundlingMode.LibraryOnly()` being set in `build.sbt`
+  -->
   <script type="text/javascript"
-    src="../target/scala-3.0.2/scalajs-bundler/main/scala-threejs-facades-examples-fastopt-bundle.js"></script>
+    src="../target/scala-3.0.2/scalajs-bundler/main/scala-threejs-facades-examples-fastopt-library.js"></script>
+  <script type="text/javascript"
+    src="../target/scala-3.0.2/scalajs-bundler/main/scala-threejs-facades-examples-fastopt-loader.js"></script>
+  <script type="text/javascript"
+    src="../target/scala-3.0.2/scalajs-bundler/main/scala-threejs-facades-examples-fastopt.js"></script>
+  <!-- when doing fullOpt, we probably don't want the above library pattern, so instead we include only the following: -->
+  <!-- <script type="test/javascript" src="../target/scala-3.0.2/scalajs-bundler/main/scala-threejs-facades-examples-opt-bundle.js"></script> -->
 </body>
 
 </html>


### PR DESCRIPTION
to address your issue in https://github.com/dcascaval/scala-threejs-facades/issues/1 -- this should work now with the latest version! Note that I changed the version and name of the typings repo, so you'll need to rerun `sbt publishLocal`. 

This PR also tweaks the bundler to use the `LibraryOnly` mode, because I found that my normal edit/compile workflow was being slowed down a lot by webpack otherwise. 

